### PR TITLE
Update durations in playlist and table

### DIFF
--- a/HelperFunctions.js
+++ b/HelperFunctions.js
@@ -1,0 +1,18 @@
+// helper function from https://stackoverflow.com/questions/4091183/html5-load-audio-time-metadata-but-not-audio
+// changed slightly to fit my needs
+export const setDurationsInPlayList = (playList, audioSource, index) => {
+  return new Promise(function (resolve) {
+    var audio = new Audio();
+
+    audio.onloadedmetadata = function () {
+      resolve(audio);
+    };
+
+    audio.preload = "metadata";
+    audio.src = audioSource;
+
+    setTimeout(function () {
+      playList.getElementAtIndex(index).value.duration = audio.duration;
+    }, 1000);
+  });
+};

--- a/HelperFunctions.js
+++ b/HelperFunctions.js
@@ -16,3 +16,19 @@ export const setDurationsInPlayList = (playList, audioSource, index) => {
     }, 1000);
   });
 };
+
+export const convertToMinutes = (trackDuration) => {
+  let minutes = Math.floor(trackDuration / 60);
+  if (minutes < 10) {
+    minutes = `0${minutes}`;
+  }
+  return minutes;
+};
+
+export const convertToSeconds = (trackDuration) => {
+  let seconds = Math.floor(trackDuration % 60);
+  if (seconds < 10) {
+    seconds = `0${seconds}`;
+  }
+  return seconds;
+};

--- a/WebAudioPlayer.js
+++ b/WebAudioPlayer.js
@@ -1,5 +1,6 @@
 import { DoublyLinkedList } from "./DoublyLinkedList.js";
 import { Track } from "./Track.js";
+import { setDurationsInPlayList } from "./HelperFunctions.js";
 
 // ============== Model ========================
 const playList = new DoublyLinkedList();
@@ -89,6 +90,9 @@ class WebAudioPlayerController {
       //duration is null because we don't know it yet; it will be set later
       const track = new Track(trackNumber, fileName, null, source);
       playList.appendElement(track);
+
+      //sets duration for each track in the playlist; has to be done asynchronously
+      setDurationsInPlayList(playList, source, i);
     }
 
     webAudioPlayerApp.renderTable();

--- a/WebAudioPlayer.js
+++ b/WebAudioPlayer.js
@@ -1,6 +1,10 @@
 import { DoublyLinkedList } from "./DoublyLinkedList.js";
 import { Track } from "./Track.js";
-import { setDurationsInPlayList } from "./HelperFunctions.js";
+import {
+  convertToMinutes,
+  convertToSeconds,
+  setDurationsInPlayList,
+} from "./HelperFunctions.js";
 
 // ============== Model ========================
 const playList = new DoublyLinkedList();
@@ -30,6 +34,22 @@ class WebAudioPlayerView {
       durationCell.textContent = playList.getElementAtIndex(i).value.duration;
 
       newRow.setAttribute("id", i + 1);
+    }
+  }
+
+  updateDurationsInTable() {
+    const playList = webAudioPlayerApp.getPlayList();
+    let currentNode = playList.head;
+    let currentIndex = 0;
+
+    while (currentNode) {
+      const durationCell = document.getElementById(`dur${currentIndex + 1}`);
+      const minutes = convertToMinutes(currentNode.value.duration);
+      const seconds = convertToSeconds(currentNode.value.duration);
+
+      durationCell.textContent = `${minutes}:${seconds}`;
+      currentNode = currentNode.next;
+      currentIndex++;
     }
   }
 
@@ -96,6 +116,11 @@ class WebAudioPlayerController {
     }
 
     webAudioPlayerApp.renderTable();
+
+    //probably better with async and await
+    setTimeout(function () {
+      webAudioPlayerApp.updateDurationsInTable();
+    }, 1000);
 
     const firstTrack = playList.head.value;
     webAudioPlayerApp.setTrack(firstTrack);
@@ -194,6 +219,10 @@ class WebAudioPlayerController {
 
   renderTable() {
     this.webAudioPlayerView.renderTable();
+  }
+
+  updateDurationsInTable() {
+    this.webAudioPlayerView.updateDurationsInTable();
   }
 
   selectTrackInTable(rowIndex) {


### PR DESCRIPTION
This sets the duration for each track. The time is converted to `mm:ss` format for the table.

It was tricky to get it working as it had to be done asynchronously. The helper function is based from https://stackoverflow.com/questions/4091183/html5-load-audio-time-metadata-but-not-audio

The delay is necessary to not get NaN, however it was only tested with ~20 tracks. There might be a chance it will say NaN with larger lists.