### PR TITLE
Delete old playlist before opening new audio files

### DIFF
--- a/WebAudioPlayer.js
+++ b/WebAudioPlayer.js
@@ -113,6 +113,11 @@ class WebAudioPlayerController {
   handleFileSelect(e) {
     if (e.target.files.length === 0) return null;
 
+    if (playList.head !== null) {
+      playList.removeAllElements();
+      webAudioPlayerApp.clearPlayListTable();
+    }
+
     const files = e.target.files;
 
     for (let i = 0; i < files.length; i++) {

--- a/WebAudioPlayer.js
+++ b/WebAudioPlayer.js
@@ -37,6 +37,18 @@ class WebAudioPlayerView {
     }
   }
 
+  clearPlayListTable() {
+    const playListTable = document.getElementById("playListTable");
+
+    while (playListTable.firstChild) playListTable.firstChild.remove();
+
+    //rebuild table header
+    const newRow = playListTable.insertRow(0);
+    newRow.insertCell(0).outerHTML = "<th>Track</th>";
+    newRow.insertCell(1).outerHTML = "<th>Filename</th>";
+    newRow.insertCell(2).outerHTML = "<th>Duration</th>";
+  }
+
   updateDurationsInTable() {
     const playList = webAudioPlayerApp.getPlayList();
     let currentNode = playList.head;
@@ -219,6 +231,10 @@ class WebAudioPlayerController {
 
   renderTable() {
     this.webAudioPlayerView.renderTable();
+  }
+
+  clearPlayListTable() {
+    this.webAudioPlayerView.clearPlayListTable();
   }
 
   updateDurationsInTable() {


### PR DESCRIPTION
This implements clearPlayListTable which removes the old rows then rebuilds the table header (quicker than looping and deleting last row each time until there is only one row left).

The old playlist and the old table are cleared before new audio files can be loaded.