### PR TITLE
Bug fixes - event listeners and media buttons

### DIFF
--- a/WebAudioPlayer.js
+++ b/WebAudioPlayer.js
@@ -99,26 +99,27 @@ class WebAudioPlayerController {
       .getElementById("player")
       .addEventListener("ended", this.handleNextTrackButton.bind(this));
 
-    const stopButton = document.getElementById("stopButton");
-    stopButton.onclick = this.handleStopButton.bind(this);
+    this.stopButton = document.getElementById("stopButton");
+    this.stopButton.onclick = this.handleStopButton.bind(this);
 
-    const playButton = document.getElementById("playButton");
-    playButton.onclick = this.handlePlayButton.bind(this);
+    this.playButton = document.getElementById("playButton");
+    this.playButton.onclick = this.handlePlayButton.bind(this);
 
-    const pauseButton = document.getElementById("pauseButton");
-    pauseButton.onclick = this.handlePauseButton;
+    this.pauseButton = document.getElementById("pauseButton");
+    this.pauseButton.onclick = this.handlePauseButton;
 
-    const previousTrackButton = document.getElementById("previousTrackButton");
-    previousTrackButton.onclick = this.handlePreviousTrackButton.bind(this);
+    this.previousTrackButton = document.getElementById("previousTrackButton");
+    this.previousTrackButton.onclick =
+      this.handlePreviousTrackButton.bind(this);
 
-    const nextTrackButton = document.getElementById("nextTrackButton");
-    nextTrackButton.onclick = this.handleNextTrackButton.bind(this);
+    this.nextTrackButton = document.getElementById("nextTrackButton");
+    this.nextTrackButton.onclick = this.handleNextTrackButton.bind(this);
 
-    const repeatButton = document.getElementById("repeatButton");
-    repeatButton.onclick = this.handleRepeatButton.bind(this);
+    this.repeatButton = document.getElementById("repeatButton");
+    this.repeatButton.onclick = this.handleRepeatButton.bind(this);
 
-    const shuffleButton = document.getElementById("shuffleButton");
-    shuffleButton.onclick = this.handleShuffleButton.bind(this);
+    this.shuffleButton = document.getElementById("shuffleButton");
+    this.shuffleButton.onclick = this.handleShuffleButton.bind(this);
   }
 
   handleFileSelect(e) {

--- a/WebAudioPlayer.js
+++ b/WebAudioPlayer.js
@@ -91,14 +91,6 @@ class WebAudioPlayerController {
     this.repeatState = "noRepeat";
     this.shuffle = false;
 
-    document
-      .getElementById("files")
-      .addEventListener("change", this.handleFileSelect.bind(this));
-
-    document
-      .getElementById("player")
-      .addEventListener("ended", this.handleNextTrackButton.bind(this));
-
     this.stopButton = document.getElementById("stopButton");
     this.stopButton.onclick = this.handleStopButton.bind(this);
 
@@ -120,6 +112,14 @@ class WebAudioPlayerController {
 
     this.shuffleButton = document.getElementById("shuffleButton");
     this.shuffleButton.onclick = this.handleShuffleButton.bind(this);
+
+    document
+      .getElementById("files")
+      .addEventListener("change", this.handleFileSelect.bind(this));
+
+    document
+      .getElementById("player")
+      .addEventListener("ended", this.nextTrackButton.onclick);
   }
 
   handleFileSelect(e) {
@@ -252,17 +252,14 @@ class WebAudioPlayerController {
     if (this.getRepeatState() === "noRepeat") {
       repeatButton.setAttribute("src", "icons/repeatTrack.gif");
       this.setRepeatState("repeatTrack");
-      player.removeEventListener(
-        "ended",
-        this.handleNextTrackButton.bind(this)
-      );
-      player.addEventListener("ended", this.handlePlayButton.bind(this));
+      player.removeEventListener("ended", this.nextTrackButton.onclick);
+      player.addEventListener("ended", this.playButton.onclick);
     } else if (this.getRepeatState() === "repeatTrack") {
       playList.convertToCircularDoublyLinkedList();
       repeatButton.setAttribute("src", "icons/repeatPlayList.gif");
       this.setRepeatState("repeatPlayList");
-      player.removeEventListener("ended", this.handlePlayButton.bind(this));
-      player.addEventListener("ended", this.handleNextTrackButton.bind(this));
+      player.removeEventListener("ended", this.playButton.onclick);
+      player.addEventListener("ended", this.nextTrackButton.onclick);
     } else {
       playList.revertBackToDoublyLinkedList();
       repeatButton.setAttribute("src", "icons/noRepeat.gif");

--- a/WebAudioPlayer.js
+++ b/WebAudioPlayer.js
@@ -160,6 +160,8 @@ class WebAudioPlayerController {
   }
 
   handleStopButton() {
+    if (playList.head === null) return null;
+
     const player = document.getElementById("player");
     const indexOfCurrentTrack = this.getIndexOfCurrentTrack();
     const currentTrackNumber =
@@ -172,6 +174,8 @@ class WebAudioPlayerController {
   }
 
   handlePlayButton() {
+    if (playList.head === null) return null;
+
     const player = document.getElementById("player");
     const indexOfCurrentTrack = this.getIndexOfCurrentTrack();
     const currentTrackNumber =
@@ -189,6 +193,8 @@ class WebAudioPlayerController {
   }
 
   handlePreviousTrackButton() {
+    if (playList.head === null) return null;
+
     const player = document.getElementById("player");
     const indexOfCurrentTrack = this.getIndexOfCurrentTrack();
     const currentTrack = playList.getElementAtIndex(indexOfCurrentTrack);
@@ -216,6 +222,8 @@ class WebAudioPlayerController {
   }
 
   handleNextTrackButton() {
+    if (playList.head === null) return null;
+
     const player = document.getElementById("player");
     const indexOfCurrentTrack = this.getIndexOfCurrentTrack();
     const currentTrack = playList.getElementAtIndex(indexOfCurrentTrack);


### PR DESCRIPTION
### Event Listener issues
After changing to using 'this' in #14 there were issues related to the event listeners after toggling Repeat which didn't happen before. The error in the console was `Uncaught (in promise) DOMException: The play() request was interrupted by a new load request.`. In my case, it triggered Next Track twice.

After reading https://stackoverflow.com/questions/33859113/javascript-removeeventlistener-not-working-inside-a-class it became clear to me that I didn't know that I didn't pass the same reference in the event listeners; they became new. That made `removeEventListener` not removing the old one because what was passed was a new reference and not what was attached before.

Now the click handlers are saved and the same reference to them can be used for the event listeners.

### Media buttons issue
Stop, Play, Previous Track and Next Track caused errors if they were clicked when the playlist was empty. This has now been fixed.
